### PR TITLE
JS injection in Text and TextArea.

### DIFF
--- a/src/Fields/Text.php
+++ b/src/Fields/Text.php
@@ -7,6 +7,7 @@ class Text extends Field
     protected $displayInIndexCallback = null;
     protected $editableHint           = false;
     protected $attributes             = '';
+    protected $shouldAllowScripts     = false;
 
     public function editableHint($editableHint = true)
     {
@@ -69,5 +70,16 @@ class Text extends Field
             return null;
         }
         return strip_tags(parent::getValue($object));
+    }
+
+    public function allowScripts()
+    {
+        $this->shouldAllowScripts = true;
+        return $this;
+    }
+
+    public function mapAttributeFromRequest($value)
+    {
+        return parent::mapAttributeFromRequest(!$this->shouldAllowScripts ? strip_tags($value) : $value);
     }
 }

--- a/src/Fields/TextArea.php
+++ b/src/Fields/TextArea.php
@@ -4,6 +4,8 @@ namespace BadChoice\Thrust\Fields;
 
 class TextArea extends Field
 {
+    protected $shouldAllowScripts = false;
+
     public $showInIndex = false;
 
     public function displayInIndex($object)
@@ -30,5 +32,17 @@ class TextArea extends Field
     public function getValue($object)
     {
         return strip_tags($object->{$this->field});
+    }
+
+
+    public function allowScripts()
+    {
+        $this->shouldAllowScripts = true;
+        return $this;
+    }
+
+    public function mapAttributeFromRequest($value)
+    {
+        return parent::mapAttributeFromRequest(!$this->shouldAllowScripts ? strip_tags($value) : $value);
     }
 }


### PR DESCRIPTION
By default, Text and TextArea not allow JS injection (strip_tags()).
To allow it: call allowScripts() method: e.g.: TextArea::make('notes')->allowScripts() or Email::make('email')->allowScripts()