### PR TITLE
XSS on displayIn.

### DIFF
--- a/src/Fields/Text.php
+++ b/src/Fields/Text.php
@@ -69,7 +69,7 @@ class Text extends Field
         if (! $object) {
             return null;
         }
-        return strip_tags(parent::getValue($object));
+        return htmlspecialchars(parent::getValue($object));
     }
 
     public function allowScripts()

--- a/src/Fields/TextArea.php
+++ b/src/Fields/TextArea.php
@@ -31,7 +31,7 @@ class TextArea extends Field
 
     public function getValue($object)
     {
-        return strip_tags($object->{$this->field});
+        return htmlspecialchars($object->{$this->field});
     }
 
 


### PR DESCRIPTION
Instead of strip_tag when display, we transform special chars (<,&..) in HTML entities. Instead of delete tags, we interpret tags harmlessly.

!!Releas version Tag!!

Linear: https://linear.app/revo/issue/REV-3017/thrust-strip-tag-on-displayin-to-htmlspecialchars