### PR TITLE
Return text type='password' if field name contains password word. (******* protection)

### DIFF
--- a/src/Fields/Text.php
+++ b/src/Fields/Text.php
@@ -50,6 +50,9 @@ class Text extends Field
 
     protected function getFieldType()
     {
+        if ( strpos(strtolower($this->field), 'password') !== false ) {
+            return 'password';
+        }
         return 'text';
     }
 


### PR DESCRIPTION
PR: https://linear.app/revo/issue/REV-3606/thrust-text-element-type=password-protection

TREURE TAG!!!

Reviewer: @PauRevo 