### PR TITLE
Check switch opacity error with xef headers.

### DIFF
--- a/src/resources/views/fields/checkIndex.blade.php
+++ b/src/resources/views/fields/checkIndex.blade.php
@@ -4,7 +4,7 @@
 @if ($value)
     <i class="fa @if($asSwitch) fa-2x fa-toggle-on @else fa-check @endif green"></i>
 @else
-    <i class="fa @if($asSwitch) fa-2x fa-toggle-off o20 @else fa-times red @endif " style="color:red"></i>
+    <i class="fa @if($asSwitch) fa-2x fa-toggle-off @else fa-times red @endif " style="color:rgba(255,0,0,0.2)"></i>
 @endif
 @if($withLinks)
     </a>


### PR DESCRIPTION
Linear: https://linear.app/revo/issue/REV-3776/thrust-check-switch-opacity-error

Before: 
<img width="192" alt="Captura de pantalla 2021-05-06 a las 9 11 25" src="https://user-images.githubusercontent.com/29859922/117256916-8c9fdf80-ae4b-11eb-99bf-0a558df1bae5.png">

After:
<img width="211" alt="Captura de pantalla 2021-05-06 a las 9 11 36" src="https://user-images.githubusercontent.com/29859922/117256920-90cbfd00-ae4b-11eb-89d2-48e7d8dc5357.png">

Reviewer: @PauRevo 