### PR TITLE
Optional Confirmation option when update thrust Resource.

### DIFF
--- a/src/Helpers/Titleable.php
+++ b/src/Helpers/Titleable.php
@@ -19,7 +19,7 @@ trait Titleable {
 	}
 
     private function translatedTitle() {
-        return ($this->title && (strpos(__($this->getTranslationPrefix().$this->title), $this->getTranslationPrefix()) === false)) ? __($this->getTranslationPrefix().$this->title) : null;
+        return Translation::useTranslationPrefix($this->title);
 	}
 
 	private function rawTitle() {
@@ -28,7 +28,7 @@ trait Titleable {
 
     private function translatedClassNameTitle() {
         $ucClassName = lcfirst($this->sanitizedClassName());
-        return strpos(__($this->getTranslationPrefix().$ucClassName), $this->getTranslationPrefix()) === false ? __($this->getTranslationPrefix().$ucClassName) : null;
+        return Translation::useTranslationPrefix($ucClassName);
 	}
 
     private function niceClassNameTitle() {

--- a/src/Helpers/Translation.php
+++ b/src/Helpers/Translation.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace BadChoice\Thrust\Helpers;
+
+
+class Translation
+{
+    public static function useTranslationPrefix($translationMessage, $noTranslationResult = null) {
+        $translationPrefix = config('thrust.translationsPrefix');
+        if ( $translationMessage && (strpos(__($translationPrefix.$translationMessage), $translationPrefix) === false) ) {
+            return __($translationPrefix.$translationMessage);
+        }
+        return $noTranslationResult;
+    }
+}

--- a/src/Html/Edit.php
+++ b/src/Html/Edit.php
@@ -73,7 +73,7 @@ class Edit
             'hideVisibility'      => $this->getPanelHideVisibilityJson(),
             'showVisibility'      => $this->getPanelShowVisibilityJson(),
             'fullPage'            => $fullPage,
-            'confirmationMessage' => $this->resource->getConfirmation()
+            'updateConfirmationMessage' => $this->resource->getUpdateConfirmationMessage()
         ])->render();
     }
 

--- a/src/Html/Edit.php
+++ b/src/Html/Edit.php
@@ -72,7 +72,8 @@ class Edit
             'object'        => $object,
             'hideVisibility'    => $this->getPanelHideVisibilityJson(),
             'showVisibility'    => $this->getPanelShowVisibilityJson(),
-            'fullPage'      => $fullPage
+            'fullPage'      => $fullPage,
+            'confirmationMessage' => $this->resource->getConfirmation()
         ])->render();
     }
 

--- a/src/Html/Edit.php
+++ b/src/Html/Edit.php
@@ -70,9 +70,9 @@ class Edit
             'resourceName'  => $this->resourceName ? : $this->resource->name(),
             'fields'        => $this->getEditFields(),
             'object'        => $object,
-            'hideVisibility'    => $this->getPanelHideVisibilityJson(),
-            'showVisibility'    => $this->getPanelShowVisibilityJson(),
-            'fullPage'      => $fullPage,
+            'hideVisibility'      => $this->getPanelHideVisibilityJson(),
+            'showVisibility'      => $this->getPanelShowVisibilityJson(),
+            'fullPage'            => $fullPage,
             'confirmationMessage' => $this->resource->getConfirmation()
         ])->render();
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -2,6 +2,7 @@
 
 namespace BadChoice\Thrust;
 
+use BadChoice\Thrust\Helpers\Translation;
 use Illuminate\Support\Str;
 use BadChoice\Thrust\ResourceFilters\Sort;
 use BadChoice\Thrust\ResourceFilters\Search;
@@ -54,7 +55,7 @@ abstract class Resource
     /**
      * @var string when resource is update will show a confirmation alert with the message specified
      */
-    public $confirmationMessage = '';
+    public $updateConfirmationMessage = '';
 
 
     /**
@@ -346,12 +347,8 @@ abstract class Resource
         return static::$sortable && !request('sort');
     }
 
-    public function getConfirmation()
+    public function getUpdateConfirmationMessage()
     {
-        $translationPrefix = config('thrust.translationsPrefix');
-        if ( $this->confirmationMessage && (strpos(__($translationPrefix.$this->confirmationMessage), $translationPrefix) === false) ) {
-            return __($translationPrefix.$this->confirmationMessage);
-        }
-        return $this->confirmationMessage;
+        return Translation::useTranslationPrefix($this->updateConfirmationMessage, $this->updateConfirmationMessage);
     }
 }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -52,7 +52,7 @@ abstract class Resource
 
 
     /**
-     * @var string Explain
+     * @var string when resource is update will show a confirmation alert with the message specified
      */
     public $confirmationMessage = '';
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -52,6 +52,12 @@ abstract class Resource
 
 
     /**
+     * @var string Explain
+     */
+    public $confirmationMessage = '';
+
+
+    /**
      * @var bool define if the resource is sortable and can be arranged in the index view
      */
     public static $sortable     = false;
@@ -338,5 +344,14 @@ abstract class Resource
     public function sortableIsActive()
     {
         return static::$sortable && !request('sort');
+    }
+
+    public function getConfirmation()
+    {
+        $translationPrefix = config('thrust.translationsPrefix');
+        if ( $this->confirmationMessage && (strpos(__($translationPrefix.$this->confirmationMessage), $translationPrefix) === false) ) {
+            return __($translationPrefix.$this->confirmationMessage);
+        }
+        return $this->confirmationMessage;
     }
 }

--- a/src/resources/views/components/saveButton.blade.php
+++ b/src/resources/views/components/saveButton.blade.php
@@ -1,4 +1,4 @@
-<button class="button-with-loading">
+<button class="button-with-loading" @if($confirmationMessage) onclick="return confirm('{{$confirmationMessage}}')" @endif>
         <span class="loadingImage">
             <i class="fa fa-circle-o-notch fa-spin"></i>
         </span>

--- a/src/resources/views/components/saveButton.blade.php
+++ b/src/resources/views/components/saveButton.blade.php
@@ -1,4 +1,4 @@
-<button class="button-with-loading" @if($confirmationMessage) onclick="return confirm('{{$confirmationMessage}}')" @endif>
+<button class="button-with-loading" @if($updateConfirmationMessage) onclick="return confirm('{{$updateConfirmationMessage}}')" @endif>
         <span class="loadingImage">
             <i class="fa fa-circle-o-notch fa-spin"></i>
         </span>

--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -23,7 +23,7 @@
     </div>
 
     @if (app(BadChoice\Thrust\ResourceGate::class)->can($resourceName, 'update', $object))
-        @include('thrust::components.saveButton', ["confirmationMessage" => $confirmationMessage])
+        @include('thrust::components.saveButton', ["updateConfirmationMessage" => $updateConfirmationMessage])
 
         @if (isset($object->id) )
             <a class="secondary button hidden" id="thrust-save-and-continue" onclick="submitAjaxForm('thrust-form-{{$object->id}}')">{{ __("thrust::messages.saveAndContinueEditing") }}</a>

--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -22,9 +22,8 @@
         @endforeach
     </div>
 
-
     @if (app(BadChoice\Thrust\ResourceGate::class)->can($resourceName, 'update', $object))
-        @include('thrust::components.saveButton')
+        @include('thrust::components.saveButton', ["confirmationMessage" => $confirmationMessage])
 
         @if (isset($object->id) )
             <a class="secondary button hidden" id="thrust-save-and-continue" onclick="submitAjaxForm('thrust-form-{{$object->id}}')">{{ __("thrust::messages.saveAndContinueEditing") }}</a>


### PR DESCRIPTION
Usage:
    public $confirmationMessage = 'message'; 
if 'message' is in thrustTranslationPrefix file (e.g. admin.message), will print translation, otherwise will print raw 'message'.

LInear: https://linear.app/revo/issue/REV-3862/thrust-option-confirmation-option-when-update-thrust-resource

!!!!! TREURE TAAGGGG YA PLSSS !!!!!

Screenshot:
<img width="1432" alt="Captura de pantalla 2021-05-17 a las 11 01 51" src="https://user-images.githubusercontent.com/29859922/118463691-58a4a400-b700-11eb-955e-c31b22dfb285.png">

Reviewer: @PauRevo 
