### PR TITLE
Translated "new" in thrust.

### DIFF
--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -2,7 +2,7 @@
         <h2> {{  trans_choice(config('thrust.translationsPrefix'). Illuminate\Support\Str::singular($resourceName), 1) }} </h2>
     @else
         <div class="configForm">
-            <h2> {{ $object->{$nameField} ?? 'New' }}</h2>
+            <h2> {{ $object->{$nameField} ?? __('thrust::messages.new') }}</h2>
         </div>
     @endif
 


### PR DESCRIPTION
Translated "new" in thrust.

https://linear.app/revo/issue/REV-3820/traduccio-a-trust